### PR TITLE
Try to fix s6-overlay-suexec: fatal: can only run as pid 1

### DIFF
--- a/vzlogger2mqtt/config.json
+++ b/vzlogger2mqtt/config.json
@@ -6,6 +6,7 @@
   "url": "https://github.com/m-reuter/ha-addons/tree/master/vzlogger2mqtt",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
   "_arch": ["armv7"],
+  "init": false,
   "startup": "system",
   "boot": "auto",
   "uart": true,


### PR DESCRIPTION
See breaking changes https://www.home-assistant.io/blog/2022/06/01/release-20226/#breaking-changes