### PR TITLE
fix for draining device at restart

### DIFF
--- a/vzlogger2mqtt/README.md
+++ b/vzlogger2mqtt/README.md
@@ -126,7 +126,7 @@ https://wiki.volkszaehler.org/software/controller/vzlogger/overview_en
 ### Meter stops reading after Home Assistant restart (HA 2026.5+)
 
 HA 2026.5 changed how USB serial devices are handed to containers, which can cause the meter's serial stream to arrive mid-frame after a restart, producing log spam like `Too much data for value` or `Too much data for unit`.
-The add-on includes a 3-second startup delay to let the device settle, and enables the vzlogger built-in HTTP server so Home Assistant can automatically restart the add-on if it stops producing readings.
+The add-on now waits briefly for USB serial devices to settle and drains any stale bytes from each configured meter device before launching `vzlogger`. It also enables the vzlogger built-in HTTP server so Home Assistant can automatically restart the add-on if it stops producing readings.
 
 For extra reliability, consider setting up an automation that restarts the add-on when no MQTT messages have been received for a configurable period.
 

--- a/vzlogger2mqtt/README.md
+++ b/vzlogger2mqtt/README.md
@@ -126,7 +126,7 @@ https://wiki.volkszaehler.org/software/controller/vzlogger/overview_en
 ### Meter stops reading after Home Assistant restart (HA 2026.5+)
 
 HA 2026.5 changed how USB serial devices are handed to containers, which can cause the meter's serial stream to arrive mid-frame after a restart, producing log spam like `Too much data for value` or `Too much data for unit`.
-The add-on now waits briefly for USB serial devices to settle and drains any stale bytes from each configured meter device before launching `vzlogger`. It also enables the vzlogger built-in HTTP server so Home Assistant can automatically restart the add-on if it stops producing readings.
+The add-on now waits briefly for USB serial devices to settle and drains any stale bytes from each configured meter device before launching `vzlogger`. It also enables the vzlogger built-in HTTP server so Home Assistant can monitor that endpoint and automatically restart the add-on if the HTTP health check stops responding.
 
 For extra reliability, consider setting up an automation that restarts the add-on when no MQTT messages have been received for a configurable period.
 

--- a/vzlogger2mqtt/config.json
+++ b/vzlogger2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "vzlogger to MQTT Gateway",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "slug": "vzlogger2mqtt",
   "description": "vzlogger - Read your Smart Meter",
   "url": "https://github.com/m-reuter/ha-addons/tree/master/vzlogger2mqtt",

--- a/vzlogger2mqtt/run.sh
+++ b/vzlogger2mqtt/run.sh
@@ -59,7 +59,6 @@ drain_serial_device() {
     local baudrate="$2"
     local parity="$3"
     local label="$4"
-    local byte=""
     local drained=0
     local deadline
     local fd
@@ -78,9 +77,9 @@ drain_serial_device() {
 
     deadline=$((SECONDS + 5))
     while (( SECONDS < deadline )); do
-        if IFS= read -r -t 0.2 -u "$fd" -N 1 byte; then
+        if IFS= read -r -t 0.2 -u "$fd" -N 1; then
             ((drained += 1))
-            while IFS= read -r -t 0.05 -u "$fd" -N 1 byte; do
+            while IFS= read -r -t 0.05 -u "$fd" -N 1; do
                 ((drained += 1))
             done
         else

--- a/vzlogger2mqtt/run.sh
+++ b/vzlogger2mqtt/run.sh
@@ -33,7 +33,7 @@ configure_serial_device() {
     local databits="${parity:0:1}"
     local parity_mode="${parity:1:1}"
     local stopbits="${parity:2:1}"
-    local stty_args=(raw "$baudrate" -echo -ixon -ixoff -crtscts)
+    local stty_args=(raw "$baudrate" -echo -ixon -ixoff -crtscts clocal)
 
     case "$databits" in
         7) stty_args+=(cs7) ;;

--- a/vzlogger2mqtt/run.sh
+++ b/vzlogger2mqtt/run.sh
@@ -21,6 +21,82 @@ MQTT_KEYPASS="$(bashio::config 'mqtt_keypass' '')"
 [[ "$MQTT_KEYFILE"  == "null" ]] && MQTT_KEYFILE=""
 [[ "$MQTT_KEYPASS"  == "null" ]] && MQTT_KEYPASS=""
 
+configure_serial_device() {
+    local device="$1"
+    local baudrate="$2"
+    local parity="$3"
+
+    if ! command -v stty >/dev/null 2>&1 || [[ ! -e "$device" ]]; then
+        return 0
+    fi
+
+    local databits="${parity:0:1}"
+    local parity_mode="${parity:1:1}"
+    local stopbits="${parity:2:1}"
+    local stty_args=(raw "$baudrate" -echo -ixon -ixoff -crtscts)
+
+    case "$databits" in
+        7) stty_args+=(cs7) ;;
+        8) stty_args+=(cs8) ;;
+    esac
+
+    case "$parity_mode" in
+        [Nn]) stty_args+=(-parenb -parodd) ;;
+        [Ee]) stty_args+=(parenb -parodd) ;;
+        [Oo]) stty_args+=(parenb parodd) ;;
+    esac
+
+    case "$stopbits" in
+        1) stty_args+=(-cstopb) ;;
+        2) stty_args+=(cstopb) ;;
+    esac
+
+    stty -F "$device" "${stty_args[@]}" 2>/dev/null || true
+}
+
+drain_serial_device() {
+    local device="$1"
+    local baudrate="$2"
+    local parity="$3"
+    local label="$4"
+    local byte=""
+    local drained=0
+    local deadline
+    local fd
+
+    if [[ -z "$device" || "$device" != /dev/* || ! -e "$device" ]]; then
+        return 0
+    fi
+
+    echo "Preparing ${label} device ${device} ..."
+    configure_serial_device "$device" "$baudrate" "$parity"
+
+    if ! exec {fd}<"$device"; then
+        echo "Warning: could not open ${device} to drain stale input."
+        return 0
+    fi
+
+    deadline=$((SECONDS + 5))
+    while (( SECONDS < deadline )); do
+        if IFS= read -r -t 0.2 -u "$fd" -N 1 byte; then
+            ((drained += 1))
+            while IFS= read -r -t 0.05 -u "$fd" -N 1 byte; do
+                ((drained += 1))
+            done
+        else
+            break
+        fi
+    done
+
+    exec {fd}<&-
+
+    if (( drained > 0 )); then
+        echo "Discarded ${drained} stale byte(s) from ${label} before startup."
+    else
+        echo "No stale bytes waiting on ${label}."
+    fi
+}
+
 # ── Meter 1 settings ─────────────────────────────────────────────────────────
 METER1_PROTOCOL="$(bashio::config 'meter1_protocol')"
 METER1_PARITY="$(bashio::config 'meter1_parity')"
@@ -202,6 +278,9 @@ echo
 
 # Give the serial device time to finish enumerating after an HA restart
 sleep 3
+
+drain_serial_device "$METER1_DEVICE" "$METER1_BAUDRATE_READ" "$METER1_PARITY" "meter1"
+drain_serial_device "$METER2_DEVICE" "${METER2_BAUDRATE_READ:-9600}" "${METER2_PARITY:-8N1}" "meter2"
 
 # Reset the log on each start so stale output does not accumulate across restarts.
 : > /vzlogger.log


### PR DESCRIPTION
Tries to address #14 
changed `vzlogger2mqtt/run.sh` to:

- briefly settle USB serial devices
- configure each configured /dev/... meter TTY
- drain stale queued bytes from meter1_device and meter2_device
- then start vzlogger
- update the README troubleshooting text to match.