### PR TITLE
upgrade to current head of pyhpsu

### DIFF
--- a/.github/workflows/ci-pyhpsu2mqtt.yml
+++ b/.github/workflows/ci-pyhpsu2mqtt.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate JSON files
         run: |
@@ -40,10 +40,10 @@ jobs:
     name: Build amd64 (no push)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Read BUILD_FROM for amd64
         id: meta
@@ -51,7 +51,7 @@ jobs:
           echo "build_from=$(jq -r '.build_from.amd64' pyhpsu2mqtt/build.json)" >> "$GITHUB_OUTPUT"
 
       - name: Build (amd64 only, no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: pyhpsu2mqtt
           push: false

--- a/.github/workflows/ci-vzlogger2mqtt.yml
+++ b/.github/workflows/ci-vzlogger2mqtt.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Validate JSON files
         run: |
@@ -39,10 +39,10 @@ jobs:
     name: Build amd64 (no push)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Read BUILD_FROM for amd64
         id: meta
@@ -50,7 +50,7 @@ jobs:
           echo "build_from=$(jq -r '.build_from.amd64' vzlogger2mqtt/build.json)" >> "$GITHUB_OUTPUT"
 
       - name: Build (amd64 only, no push)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: vzlogger2mqtt
           push: false

--- a/.github/workflows/release-pyhpsu2mqtt.yml
+++ b/.github/workflows/release-pyhpsu2mqtt.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
           esac
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: pyhpsu2mqtt
           push: true

--- a/.github/workflows/release-vzlogger2mqtt.yml
+++ b/.github/workflows/release-vzlogger2mqtt.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
           esac
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: vzlogger2mqtt
           push: true

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -44,7 +44,8 @@ RUN apk add --no-cache \
 
 # Copy data for add-on
 COPY pyhpsu.conf /
+COPY mqtt_command_daemon.py /usr/local/bin/mqtt_command_daemon.py
 COPY run.sh /
-RUN chmod a+x /run.sh
+RUN chmod a+x /run.sh /usr/local/bin/mqtt_command_daemon.py
 
 CMD [ "/run.sh" ]

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -45,7 +45,9 @@ RUN apk add --no-cache \
 # Copy data for add-on
 COPY pyhpsu.conf /
 COPY mqtt_command_daemon.py /usr/local/bin/mqtt_command_daemon.py
+COPY mqtt_plugin.py /usr/local/share/pyhpsu-mqtt-plugin.py
 COPY run.sh /
-RUN chmod a+x /run.sh /usr/local/bin/mqtt_command_daemon.py
+RUN cp /usr/local/share/pyhpsu-mqtt-plugin.py /usr/lib/python3/dist-packages/HPSU/plugins/mqtt.py \
+    && chmod a+x /run.sh /usr/local/bin/mqtt_command_daemon.py
 
 CMD [ "/run.sh" ]

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -44,10 +44,12 @@ RUN apk add --no-cache \
 
 # Copy data for add-on
 COPY pyhpsu.conf /
+COPY canpi.py /usr/local/share/pyhpsu-canpi.py
 COPY mqtt_command_daemon.py /usr/local/bin/mqtt_command_daemon.py
 COPY mqtt_plugin.py /usr/local/share/pyhpsu-mqtt-plugin.py
 COPY run.sh /
 RUN cp /usr/local/share/pyhpsu-mqtt-plugin.py /usr/lib/python3/dist-packages/HPSU/plugins/mqtt.py \
+    && cp /usr/local/share/pyhpsu-canpi.py /usr/lib/python3/dist-packages/HPSU/canpi.py \
     && chmod a+x /run.sh /usr/local/bin/mqtt_command_daemon.py
 
 CMD [ "/run.sh" ]

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -3,6 +3,7 @@ FROM $BUILD_FROM
 ARG PYHPSU_REF=4fcb37d7c28c970073d720923c28dc781eb92a85
 
 ENV LANG=C.UTF-8
+ENV PYTHONUNBUFFERED=1
 
 # install packages
 RUN apk add --no-cache \

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -1,8 +1,8 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=homeassistant/amd64-base:3.18
 FROM $BUILD_FROM
 ARG PYHPSU_REF=4fcb37d7c28c970073d720923c28dc781eb92a85
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # install packages
 RUN apk add --no-cache \

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -47,9 +47,11 @@ COPY pyhpsu.conf /
 COPY canpi.py /usr/local/share/pyhpsu-canpi.py
 COPY mqtt_command_daemon.py /usr/local/bin/mqtt_command_daemon.py
 COPY mqtt_plugin.py /usr/local/share/pyhpsu-mqtt-plugin.py
+COPY pyHPSU.py /usr/local/share/pyhpsu-entrypoint.py
 COPY run.sh /
 RUN cp /usr/local/share/pyhpsu-mqtt-plugin.py /usr/lib/python3/dist-packages/HPSU/plugins/mqtt.py \
     && cp /usr/local/share/pyhpsu-canpi.py /usr/lib/python3/dist-packages/HPSU/canpi.py \
-    && chmod a+x /run.sh /usr/local/bin/mqtt_command_daemon.py
+    && cp /usr/local/share/pyhpsu-entrypoint.py /usr/bin/pyHPSU.py \
+    && chmod a+x /run.sh /usr/local/bin/mqtt_command_daemon.py /usr/bin/pyHPSU.py
 
 CMD [ "/run.sh" ]

--- a/pyhpsu2mqtt/Dockerfile
+++ b/pyhpsu2mqtt/Dockerfile
@@ -1,10 +1,10 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
+ARG PYHPSU_REF=4fcb37d7c28c970073d720923c28dc781eb92a85
 
 ENV LANG C.UTF-8
 
 # install packages
-# eventually pull pyhpsu master once mqtt is merged from testing
 RUN apk add --no-cache \
     ca-certificates \
     git \
@@ -21,8 +21,9 @@ RUN apk add --no-cache \
     && pip3 install \
         --no-cache-dir \
         --prefer-binary \
+        --upgrade \
         python-can \
-        serial \
+        pyserial \
         paho-mqtt \
         pika \
         requests \
@@ -32,11 +33,12 @@ RUN apk add --no-cache \
         -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
         -exec rm -rf '{}' + \
     \
-    && cd /opt \
-    && git clone https://github.com/Spanni26/pyHPSU.git \
-    && cd pyHPSU \
-    && git fetch origin pull/54/head:mqtt \
-    && git checkout mqtt \
+    && mkdir -p /opt/pyHPSU \
+    && cd /opt/pyHPSU \
+    && git init \
+    && git remote add origin https://github.com/Spanni26/pyHPSU.git \
+    && git fetch --depth 1 origin "${PYHPSU_REF}" \
+    && git checkout --detach FETCH_HEAD \
     && chmod +x install.sh \
     && sh install.sh
 

--- a/pyhpsu2mqtt/README.md
+++ b/pyhpsu2mqtt/README.md
@@ -194,6 +194,12 @@ Topic for commands going from MQTT to pyHPSU (default: `command`).
 
 Timeout in seconds for the CAN interface (default: `0.05`).
 
+### canpi_log_level (list)
+
+Log level for CAN bus retry/timeout diagnostics (`DEBUG`, `INFO`, `WARNING`, or `ERROR`; default: `ERROR`). At the
+default level, only final failures after all retries are logged. Set to `WARNING` to also see individual retry attempts
+and raw `SEND`/`RECV` bytes, which is useful when diagnosing bus issues but produces much more log output.
+
 ### jobs (list of dict)
 
 pyHPSU jobs are commands that are passed to the heat pump at regular intervals to read values and report them back to

--- a/pyhpsu2mqtt/README.md
+++ b/pyhpsu2mqtt/README.md
@@ -192,7 +192,7 @@ Topic for commands going from MQTT to pyHPSU (default: `command`).
 
 ### canpi_timeout (float)
 
-Timeout in seconds for the CAN interface (default: `0.05`).
+Timeout in seconds for the CAN interface (default: `0.1`).
 
 ### canpi_log_level (list)
 

--- a/pyhpsu2mqtt/README.md
+++ b/pyhpsu2mqtt/README.md
@@ -1,11 +1,17 @@
 # pyHPSU to MQTT Add-on for ROTEX Heat Pumps
+
 [![CI](https://github.com/m-reuter/ha-addons/actions/workflows/ci-pyhpsu2mqtt.yml/badge.svg)](https://github.com/m-reuter/ha-addons/actions/workflows/ci-pyhpsu2mqtt.yml)
 
-This add-on provides [pyHPSU](https://github.com/Spanni26/pyHPSU) with MQTT bi-directional communication as a Home Assistant add-on.
+This add-on provides [pyHPSU](https://github.com/Spanni26/pyHPSU) with MQTT bi-directional communication as a Home
+Assistant add-on.
 pyHPSU is a Python toolbox to communicate with a Rotex/Daikin heat pump via CAN bus (J13).
-Tested hardware includes Raspberry Pi systems with either a USB CAN adapter supported by the Linux `gs_usb` driver (for example a CANable/candleLight-compatible adapter) or a PiCAN 2 HAT. ELM327 did not work for me.
+Tested hardware includes Raspberry Pi systems with either a USB CAN adapter supported by the Linux `gs_usb` driver (for
+example a CANable/candleLight-compatible adapter) or a PiCAN 2 HAT. ELM327 did not work for me.
 
-You can read many different variables (flow, pressure, temperatures, statistics, and more) from the Rotex heat pump, and you can also control it by writing variables. For example, you can temporarily raise the hot water target temperature to trigger water heating with the heat pump instead of the less efficient electrical heating rod. Variables and commands are passed via MQTT, so you need an MQTT broker running in Home Assistant, for example the Mosquitto add-on.
+You can read many different variables (flow, pressure, temperatures, statistics, and more) from the Rotex heat pump, and
+you can also control it by writing variables. For example, you can temporarily raise the hot water target temperature to
+trigger water heating with the heat pump instead of the less efficient electrical heating rod. Variables and commands
+are passed via MQTT, so you need an MQTT broker running in Home Assistant, for example the Mosquitto add-on.
 
 Possible commands are available in the upstream pyHPSU project:
 [pyHPSU Commands CSV](https://github.com/Spanni26/pyHPSU/tree/master/etc/pyHPSU)
@@ -19,7 +25,8 @@ Possible commands are available in the upstream pyHPSU project:
 
 ## Hardware setup
 
-For this add-on you need a Raspberry Pi running Home Assistant and a working `can0` interface on the host OS. The add-on talks to the host CAN interface directly because it runs with host networking enabled.
+For this add-on you need a Raspberry Pi running Home Assistant and a working `can0` interface on the host OS. The add-on
+talks to the host CAN interface directly because it runs with host networking enabled.
 
 Before configuring the add-on, verify that the host can already talk to the heat pump:
 
@@ -36,7 +43,8 @@ sudo ip link set can0 type can bitrate 20000
 sudo ip link set can0 up
 ```
 
-After that, a quick smoke test with `candump` can confirm that the CAN interface is working while something is actively polling the heat pump, for example `pyHPSU`, the `pyhpsu2mqtt` add-on, or another CAN query tool:
+After that, a quick smoke test with `candump` can confirm that the CAN interface is working while something is actively
+polling the heat pump, for example `pyHPSU`, the `pyhpsu2mqtt` add-on, or another CAN query tool:
 
 ```bash
 candump -x -e can0
@@ -44,7 +52,8 @@ candump -x -e can0
 
 ### USB CAN adapter (`gs_usb`, recommended on Bookworm)
 
-On current Raspberry Pi OS / Bookworm systems, a USB CAN adapter supported by the Linux `gs_usb` driver is often the easiest option. This includes candleLight/CANable-compatible adapters that show up as a `gs_usb` device.
+On current Raspberry Pi OS / Bookworm systems, a USB CAN adapter supported by the Linux `gs_usb` driver is often the
+easiest option. This includes candleLight/CANable-compatible adapters that show up as a `gs_usb` device.
 
 1. Plug in the adapter and confirm that Linux detects it:
 
@@ -53,11 +62,14 @@ On current Raspberry Pi OS / Bookworm systems, a USB CAN adapter supported by th
    ```
 
 2. Bring up `can0` with bitrate `20000` as shown above.
-3. Start `candump -x -e can0`, then trigger traffic by running `pyHPSU`, starting the `pyhpsu2mqtt` add-on, or sending another known-good CAN query, and confirm that frames appear.
+3. Start `candump -x -e can0`, then trigger traffic by running `pyHPSU`, starting the `pyhpsu2mqtt` add-on, or sending
+   another known-good CAN query, and confirm that frames appear.
 
-If the adapter is detected but `cansend`/`candump` do not work reliably on Bookworm, updating the adapter to current candleLight firmware may help. Some older firmware revisions appear to behave badly with newer `gs_usb` stacks.
+If the adapter is detected but `cansend`/`candump` do not work reliably on Bookworm, updating the adapter to current
+candleLight firmware may help. Some older firmware revisions appear to behave badly with newer `gs_usb` stacks.
 
-To bring `can0` up automatically at boot and after a USB replug, use a small helper script with a templated `systemd` service plus a `udev` rule:
+To bring `can0` up automatically at boot and after a USB replug, use a small helper script with a templated `systemd`
+service plus a `udev` rule:
 
 ```sh
 #!/bin/sh
@@ -72,14 +84,14 @@ Save that as `/usr/local/sbin/can-up`, make it executable, then create `/etc/sys
 
 ```ini
 [Unit]
-Description=Bring up %I CAN
-BindsTo=sys-subsystem-net-devices-%i.device
-After=sys-subsystem-net-devices-%i.device
+Description = Bring up %I CAN
+BindsTo = sys-subsystem-net-devices-%i.device
+After = sys-subsystem-net-devices-%i.device
 
 [Service]
-Type=oneshot
-ExecStart=/usr/local/sbin/can-up %I
-RemainAfterExit=yes
+Type = oneshot
+ExecStart = /usr/local/sbin/can-up %I
+RemainAfterExit = yes
 ```
 
 And `/etc/udev/rules.d/80-can0-auto-up.rules`:
@@ -98,7 +110,9 @@ sudo udevadm trigger -c add /sys/class/net/can0
 
 ### PiCAN 2 HAT
 
-If you use a PiCAN 2 HAT instead, first set up the HAT according to its [documentation](https://raspberry-valley.azurewebsites.net/ref/Raspberry-Pi-PICAN2-Hat-User-Guide.pdf) and the pyHPSU [README](https://github.com/Spanni26/pyHPSU/blob/master/README.md), then reboot.
+If you use a PiCAN 2 HAT instead, first set up the HAT according to
+its [documentation](https://raspberry-valley.azurewebsites.net/ref/Raspberry-Pi-PICAN2-Hat-User-Guide.pdf) and the
+pyHPSU [README](https://github.com/Spanni26/pyHPSU/blob/master/README.md), then reboot.
 
 For this you need access to the host OS:
 
@@ -130,9 +144,11 @@ iface can0 inet manual
      down /sbin/ifconfig $IFACE down
 ```
 
-Then connect CAN-H and CAN-L to your RoCon BM1 board J13 CAN-H (pin 1) and CAN-L (pin 2) at your own risk (see also the pyHPSU disclaimer).
+Then connect CAN-H and CAN-L to your RoCon BM1 board J13 CAN-H (pin 1) and CAN-L (pin 2) at your own risk (see also the
+pyHPSU disclaimer).
 For the connection you need a twisted pair, for instance one pair from an Ethernet cable.
-When working on the heat pump, remove the plastic cover, switch off the pump, then switch off the fuse switches and restore them in reverse order when done.
+When working on the heat pump, remove the plastic cover, switch off the pump, then switch off the fuse switches and
+restore them in reverse order when done.
 
 ## Configuration
 
@@ -180,7 +196,8 @@ Timeout in seconds for the CAN interface (default: `0.05`).
 
 ### jobs (list of dict)
 
-pyHPSU jobs are commands that are passed to the heat pump at regular intervals to read values and report them back to MQTT. These jobs must be entered as a list of dictionaries with `command` and `interval` pairs, for example:
+pyHPSU jobs are commands that are passed to the heat pump at regular intervals to read values and report them back to
+MQTT. These jobs must be entered as a list of dictionaries with `command` and `interval` pairs, for example:
 
 ```yaml
 - command: t_dhw
@@ -189,14 +206,27 @@ pyHPSU jobs are commands that are passed to the heat pump at regular intervals t
   interval: 10
 ```
 
-This reads the domestic hot water temperature (`t_dhw`) and the current heat generator temperature (`t_hs`) every 10 seconds.
-With the default `mqtt_prefix` of `rotex`, results are written to MQTT as `/rotex/t_dhw` and `/rotex/t_hs` with their respective values as payloads. If you changed `mqtt_prefix`, replace `rotex` in the examples below with your configured prefix.
+This reads the domestic hot water temperature (`t_dhw`) and the current heat generator temperature (`t_hs`) every 10
+seconds.
+With the default `mqtt_prefix` of `rotex`, results are written to MQTT as `/rotex/t_dhw` and `/rotex/t_hs` with their
+respective values as payloads. If you changed `mqtt_prefix`, replace `rotex` in the examples below with your configured
+prefix.
 
-To confirm that the add-on is publishing to MQTT, use Home Assistant's MQTT integration and listen temporarily on `<mqtt_prefix>/#` under `Settings` -> `Devices & Services` -> `MQTT` -> `Configure` -> `Listen to a topic`. For example, if `mqtt_prefix` is left at the default, listen on `rotex/#`.
+To confirm that the add-on is publishing to MQTT, use Home Assistant's MQTT integration and listen temporarily on
+`<mqtt_prefix>/#` under `Settings` -> `Devices & Services` -> `MQTT` -> `Configure` -> `Listen to a topic`. For example,
+if `mqtt_prefix` is left at the default, listen on `rotex/#`.
+
+Not every command in the [pyHPSU Commands CSV](https://github.com/Spanni26/pyHPSU/tree/master/etc/pyHPSU) is guaranteed
+to work on every heat pump variant/firmware. If the log repeatedly shows `msg not sync, timeout` for one specific
+command while other jobs update fine, that command's reply likely doesn't match what pyHPSU expects on your hardware (
+for example `quiet` and `mode` failed this way on a Rotex unit); remove it from your `jobs` list rather than treating it
+as a bus problem.
 
 ## Home Assistant integration
 
-In Home Assistant you can read values from MQTT by adding sensors in your `configuration.yaml` (for example via the File Editor add-on). The examples below use the default `mqtt_prefix` of `rotex`; replace it with your configured prefix if you changed it:
+In Home Assistant you can read values from MQTT by adding sensors in your `configuration.yaml` (for example via the File
+Editor add-on). The examples below use the default `mqtt_prefix` of `rotex`; replace it with your configured prefix if
+you changed it:
 
 ```yaml
 sensor:
@@ -207,7 +237,8 @@ sensor:
     device_class: "temperature"
 ```
 
-Writing to the heat pump, for example adjusting the `t_dhw_setpoint1` hot water target, can be done via an automation in `automations.yaml`:
+Writing to the heat pump, for example adjusting the `t_dhw_setpoint1` hot water target, can be done via an automation in
+`automations.yaml`:
 
 ```yaml
 - id: 'make_warm_water'
@@ -236,9 +267,12 @@ Writing to the heat pump, for example adjusting the `t_dhw_setpoint1` hot water 
 ```
 
 This checks at 19:00 whether the warm water temperature is below 46 to reduce unnecessary write operations.
-It then sets `t_dhw_setpoint1` to 51 degrees, which triggers hot water mode, and later resets it to 48 degrees, which is the default for the rest of the day. You can also attach a Lovelace button to this automation to quickly make hot water before returning home.
+It then sets `t_dhw_setpoint1` to 51 degrees, which triggers hot water mode, and later resets it to 48 degrees, which is
+the default for the rest of the day. You can also attach a Lovelace button to this automation to quickly make hot water
+before returning home.
 
-The advantage here is that no electric heating rod is used unless the heat pump exceeds the time limit before reaching the target temperature, which is usually 50 minutes by default.
+The advantage here is that no electric heating rod is used unless the heat pump exceeds the time limit before reaching
+the target temperature, which is usually 50 minutes by default.
 
 ## Additional notes
 
@@ -249,7 +283,8 @@ If you know how to limit access to `can0` more narrowly, let me know.
 
 ### Rotex heat pump settings
 
-If you want to optimize your heat pump, take a look at https://m-reuter.github.io/Rotex-Daikin-WP for an introduction and recommended settings (in German).
+If you want to optimize your heat pump, take a look at https://m-reuter.github.io/Rotex-Daikin-WP for an introduction
+and recommended settings (in German).
 
 ## Thanks
 

--- a/pyhpsu2mqtt/README.md
+++ b/pyhpsu2mqtt/README.md
@@ -196,9 +196,10 @@ Timeout in seconds for the CAN interface (default: `0.05`).
 
 ### canpi_log_level (list)
 
-Log level for CAN bus retry/timeout diagnostics (`DEBUG`, `INFO`, `WARNING`, or `ERROR`; default: `ERROR`). At the
-default level, only final failures after all retries are logged. Set to `WARNING` to also see individual retry attempts
-and raw `SEND`/`RECV` bytes, which is useful when diagnosing bus issues but produces much more log output.
+Log level for CAN bus retry/timeout diagnostics (`WARNING` or `ERROR`; default: `ERROR`). At the default level, only
+final failures after all retries are logged. Set to `WARNING` to also see individual retry attempts and raw
+`SEND`/`RECV` bytes, which is useful when diagnosing bus issues but produces much more log output. This setting only
+affects CAN bus diagnostics; other log lines (for example from the MQTT command listener) are unaffected.
 
 ### jobs (list of dict)
 

--- a/pyhpsu2mqtt/README.md
+++ b/pyhpsu2mqtt/README.md
@@ -285,8 +285,11 @@ the target temperature, which is usually 50 minutes by default.
 
 ### Security and permissions
 
-To access the host `can0` interface (PiCAN 2 HAT), this add-on currently needs `--network host`.
-If you know how to limit access to `can0` more narrowly, let me know.
+This add-on runs with `host_network: true` (`--network host`) so it can access the host's `can0` interface directly —
+whether that interface comes from a USB `gs_usb` adapter or a PiCAN 2 HAT, it lives in the host's network namespace, and
+without host networking the container would not see it at all. This grants the container the host's full network stack,
+not just `can0`; narrowing that down isn't practical here since CAN interfaces are network devices tied to a Linux
+network namespace, not something a capability like `NET_ADMIN` alone can expose from the host.
 
 ### Rotex heat pump settings
 

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -5,6 +5,7 @@ import configparser
 import fcntl
 import os
 import sys
+from datetime import datetime
 
 try:
     import can
@@ -42,6 +43,10 @@ class CanPI(object):
                 bus.shutdown()
             except Exception:
                 pass
+
+    def _log(self, level, msg):
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+        self.hpsu.printd(level, "%s - %s" % (timestamp, msg))
 
     def get_with_default(self, config, section, name, default):
         if "config" not in config.sections():
@@ -109,7 +114,7 @@ class CanPI(object):
             msg = self.make_can_message(receiver_id, msg_data)
             self.bus.send(msg)
         except Exception as exc:
-            self.hpsu.printd("exception", f"CanPI {cmd_name}, Error sending msg: {exc}")
+            self._log("exception", f"CanPI {cmd_name}, Error sending msg: {exc}")
 
         if setValue:
             return "OK"
@@ -120,7 +125,7 @@ class CanPI(object):
             try:
                 rc_bus = self.bus.recv(self.timeout)
             except Exception:
-                self.hpsu.printd("exception", f"CanPI {cmd_name}, Error recv")
+                self._log("exception", f"CanPI {cmd_name}, Error recv")
 
             if rc_bus:
                 if (
@@ -138,14 +143,14 @@ class CanPI(object):
                         rc_bus.data[6],
                     )
 
-                self.hpsu.printd("error", "CanPI %s, SEND:%s" % (cmd_name, str(msg_data)))
-                self.hpsu.printd("error", "CanPI %s, RECV:%s" % (cmd_name, str(rc_bus.data)))
+                self._log("error", "CanPI %s, SEND:%s" % (cmd_name, str(msg_data)))
+                self._log("error", "CanPI %s, RECV:%s" % (cmd_name, str(rc_bus.data)))
             else:
-                self.hpsu.printd("error", "CanPI %s, Not aquired bus" % cmd_name)
+                self._log("error", "CanPI %s, Not aquired bus" % cmd_name)
 
-            self.hpsu.printd("warning", "CanPI %s, msg not sync, retry: %s" % (cmd_name, retry_count))
+            self._log("warning", "CanPI %s, msg not sync, retry: %s" % (cmd_name, retry_count))
             if retry_count >= self.retry:
-                self.hpsu.printd("error", "CanPI %s, msg not sync, timeout" % cmd_name)
+                self._log("error", "CanPI %s, msg not sync, timeout" % cmd_name)
                 not_timeout = False
 
         return "KO"

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -60,9 +60,6 @@ class CanPI(object):
         print("%s - %s - %s" % (timestamp, level.upper(), msg))
 
     def get_with_default(self, config, section, name, default):
-        if "config" not in config.sections():
-            return default
-
         if config.has_option(section, name):
             return config.get(section, name)
         return default

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -20,6 +20,9 @@ class CanPI(object):
     timeout = None
     retry = None
 
+    # matches Python logging's severity ordering, and PR#54's --log_level default of ERROR
+    _LEVELS = {"debug": 10, "info": 20, "warning": 30, "error": 40, "exception": 40}
+
     def __init__(self, hpsu=None):
         self.hpsu = hpsu
         try:
@@ -35,6 +38,8 @@ class CanPI(object):
         config.read(ini_file)
         self.timeout = float(self.get_with_default(config=config, section="CANPI", name="timeout", default=0.05))
         self.retry = float(self.get_with_default(config=config, section="CANPI", name="retry", default=15))
+        log_level = self.get_with_default(config=config, section="CANPI", name="log_level", default="ERROR")
+        self.log_level_value = self._LEVELS.get(log_level.lower(), self._LEVELS["error"])
 
     def __del__(self):
         bus = getattr(self, "bus", None)
@@ -45,6 +50,8 @@ class CanPI(object):
                 pass
 
     def _log(self, level, msg):
+        if self._LEVELS.get(level, self._LEVELS["error"]) < self.log_level_value:
+            return
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
         self.hpsu.printd(level, "%s - %s" % (timestamp, msg))
 
@@ -143,10 +150,10 @@ class CanPI(object):
                         rc_bus.data[6],
                     )
 
-                self._log("error", "CanPI %s, SEND:%s" % (cmd_name, str(msg_data)))
-                self._log("error", "CanPI %s, RECV:%s" % (cmd_name, str(rc_bus.data)))
+                self._log("warning", "CanPI %s, SEND:%s" % (cmd_name, str(msg_data)))
+                self._log("warning", "CanPI %s, RECV:%s" % (cmd_name, str(rc_bus.data)))
             else:
-                self._log("error", "CanPI %s, Not aquired bus" % cmd_name)
+                self._log("warning", "CanPI %s, Not aquired bus" % cmd_name)
 
             self._log("warning", "CanPI %s, msg not sync, retry: %s" % (cmd_name, retry_count))
             if retry_count >= self.retry:

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -52,8 +52,12 @@ class CanPI(object):
     def _log(self, level, msg):
         if self._LEVELS.get(level, self._LEVELS["error"]) < self.log_level_value:
             return
+        logger = getattr(self.hpsu, "logger", None)
+        if logger:
+            getattr(logger, "error" if level == "exception" else level)(msg)
+            return
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
-        self.hpsu.printd(level, "%s - %s" % (timestamp, msg))
+        print("%s - %s - %s" % (timestamp, level.upper(), msg))
 
     def get_with_default(self, config, section, name, default):
         if "config" not in config.sections():

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -80,13 +80,13 @@ class CanPI(object):
             )
 
     def sendCommandWithID(self, cmd, setValue=None, priority=1):
-        if setValue:
+        if setValue is not None:
             receiver_id = 0x680
         else:
             receiver_id = int(cmd["id"], 16)
         command = cmd["command"]
 
-        if setValue:
+        if setValue is not None:
             command = command[:1] + "2" + command[2:]
             if command[6:8] != "FA":
                 command = command[:3] + "00 FA" + command[2:8]
@@ -124,7 +124,7 @@ class CanPI(object):
         except Exception as exc:
             self._log("exception", f"CanPI {cmd_name}, Error sending msg: {exc}")
 
-        if setValue:
+        if setValue is not None:
             return "OK"
 
         while not_timeout:

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -104,7 +104,7 @@ class CanPI(object):
                 command = command + " %02X %02X" % (setValue >> 8, setValue & 0xFF)
             if cmd["type"] == "value":
                 setValue = int(setValue)
-                command = command + " 00 %02X" % (setValue)
+                command = command + " %02X %02X" % (setValue >> 8, setValue & 0xFF)
 
         msg_data = [int(r, 16) for r in command.split(" ")]
 

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -154,7 +154,7 @@ class CanPI(object):
                 self._log("warning", "CanPI %s, SEND:%s" % (cmd_name, str(msg_data)))
                 self._log("warning", "CanPI %s, RECV:%s" % (cmd_name, str(rc_bus.data)))
             else:
-                self._log("warning", "CanPI %s, Not aquired bus" % cmd_name)
+                self._log("warning", "CanPI %s, Not acquired bus" % cmd_name)
 
             self._log("warning", "CanPI %s, msg not sync, retry: %s" % (cmd_name, retry_count))
             if retry_count >= self.retry:

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import configparser
+import fcntl
+import os
+import sys
+
+try:
+    import can
+except Exception:
+    pass
+
+
+LOCK_FILE = "/run/pyhpsu-can.lock"
+
+
+class CanPI(object):
+    hpsu = None
+    timeout = None
+    retry = None
+
+    def __init__(self, hpsu=None):
+        self.hpsu = hpsu
+        try:
+            self.bus = can.interface.Bus(channel="can0", bustype="socketcan")
+        except can.CanInterfaceNotImplementedError:
+            self.bus = can.interface.Bus(channel="can0", bustype="socketcan_native")
+        except Exception:
+            self.hpsu.printd("exception", "Error opening bus can0")
+            sys.exit(9)
+
+        config = configparser.ConfigParser()
+        ini_file = "%s/%s.conf" % (self.hpsu.pathCOMMANDS, "pyhpsu")
+        config.read(ini_file)
+        self.timeout = float(self.get_with_default(config=config, section="CANPI", name="timeout", default=0.05))
+        self.retry = float(self.get_with_default(config=config, section="CANPI", name="retry", default=15))
+
+    def get_with_default(self, config, section, name, default):
+        if "config" not in config.sections():
+            return default
+
+        if config.has_option(section, name):
+            return config.get(section, name)
+        return default
+
+    def make_can_message(self, receiver, data):
+        try:
+            return can.Message(
+                arbitration_id=receiver,
+                data=data,
+                is_extended_id=False,
+            )
+        except TypeError:
+            return can.Message(
+                arbitration_id=receiver,
+                data=data,
+                extended_id=False,
+                dlc=len(data),
+            )
+
+    def sendCommandWithID(self, cmd, setValue=None, priority=1):
+        if setValue:
+            receiver_id = 0x680
+        else:
+            receiver_id = int(cmd["id"], 16)
+        command = cmd["command"]
+
+        if setValue:
+            command = command[:1] + "2" + command[2:]
+            if command[6:8] != "FA":
+                command = command[:3] + "00 FA" + command[2:8]
+            command = command[:14]
+            if cmd["type"] == "longint":
+                setValue = int(setValue)
+                command = command + " 00 %02X" % (setValue)
+            if cmd["type"] == "int":
+                setValue = int(setValue)
+                command = command + " %02X 00" % (setValue)
+            if cmd["type"] == "float":
+                setValue = int(setValue)
+                if setValue < 0:
+                    setValue = 0x10000 + setValue
+                command = command + " %02X %02X" % (setValue >> 8, setValue & 0xFF)
+            if cmd["type"] == "value":
+                setValue = int(setValue)
+                command = command + " 00 %02X" % (setValue)
+
+        msg_data = [int(r, 16) for r in command.split(" ")]
+
+        os.makedirs(os.path.dirname(LOCK_FILE), exist_ok=True)
+        with open(LOCK_FILE, "w") as lock_handle:
+            fcntl.flock(lock_handle, fcntl.LOCK_EX)
+            return self._exchange(receiver_id, msg_data, setValue=setValue)
+
+    def _exchange(self, receiver_id, msg_data, setValue=None):
+        not_timeout = True
+        retry_count = 0
+
+        try:
+            msg = self.make_can_message(receiver_id, msg_data)
+            self.bus.send(msg)
+        except Exception as exc:
+            self.hpsu.printd("exception", f"Error sending msg: {exc}")
+
+        if setValue:
+            return "OK"
+
+        while not_timeout:
+            retry_count += 1
+            rc_bus = None
+            try:
+                rc_bus = self.bus.recv(self.timeout)
+            except Exception:
+                self.hpsu.printd("exception", "Error recv")
+
+            if rc_bus:
+                if (
+                    msg_data[2] == 0xFA
+                    and msg_data[3] == rc_bus.data[3]
+                    and msg_data[4] == rc_bus.data[4]
+                ) or (msg_data[2] != 0xFA and msg_data[2] == rc_bus.data[2]):
+                    return "%02X %02X %02X %02X %02X %02X %02X" % (
+                        rc_bus.data[0],
+                        rc_bus.data[1],
+                        rc_bus.data[2],
+                        rc_bus.data[3],
+                        rc_bus.data[4],
+                        rc_bus.data[5],
+                        rc_bus.data[6],
+                    )
+
+                self.hpsu.printd("error", "SEND:%s" % (str(msg_data)))
+                self.hpsu.printd("error", "RECV:%s" % (str(rc_bus.data)))
+            else:
+                self.hpsu.printd("error", "Not aquired bus")
+
+            self.hpsu.printd("warning", "msg not sync, retry: %s" % retry_count)
+            if retry_count >= self.retry:
+                self.hpsu.printd("error", "msg not sync, timeout")
+                not_timeout = False
+
+        return "KO"

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -98,17 +98,18 @@ class CanPI(object):
         os.makedirs(os.path.dirname(LOCK_FILE), exist_ok=True)
         with open(LOCK_FILE, "w") as lock_handle:
             fcntl.flock(lock_handle, fcntl.LOCK_EX)
-            return self._exchange(receiver_id, msg_data, setValue=setValue)
+            return self._exchange(cmd, receiver_id, msg_data, setValue=setValue)
 
-    def _exchange(self, receiver_id, msg_data, setValue=None):
+    def _exchange(self, cmd, receiver_id, msg_data, setValue=None):
         not_timeout = True
         retry_count = 0
+        cmd_name = cmd["name"]
 
         try:
             msg = self.make_can_message(receiver_id, msg_data)
             self.bus.send(msg)
         except Exception as exc:
-            self.hpsu.printd("exception", f"Error sending msg: {exc}")
+            self.hpsu.printd("exception", f"CanPI {cmd_name}, Error sending msg: {exc}")
 
         if setValue:
             return "OK"
@@ -119,7 +120,7 @@ class CanPI(object):
             try:
                 rc_bus = self.bus.recv(self.timeout)
             except Exception:
-                self.hpsu.printd("exception", "Error recv")
+                self.hpsu.printd("exception", f"CanPI {cmd_name}, Error recv")
 
             if rc_bus:
                 if (
@@ -137,14 +138,14 @@ class CanPI(object):
                         rc_bus.data[6],
                     )
 
-                self.hpsu.printd("error", "SEND:%s" % (str(msg_data)))
-                self.hpsu.printd("error", "RECV:%s" % (str(rc_bus.data)))
+                self.hpsu.printd("error", "CanPI %s, SEND:%s" % (cmd_name, str(msg_data)))
+                self.hpsu.printd("error", "CanPI %s, RECV:%s" % (cmd_name, str(rc_bus.data)))
             else:
-                self.hpsu.printd("error", "Not aquired bus")
+                self.hpsu.printd("error", "CanPI %s, Not aquired bus" % cmd_name)
 
-            self.hpsu.printd("warning", "msg not sync, retry: %s" % retry_count)
+            self.hpsu.printd("warning", "CanPI %s, msg not sync, retry: %s" % (cmd_name, retry_count))
             if retry_count >= self.retry:
-                self.hpsu.printd("error", "msg not sync, timeout")
+                self.hpsu.printd("error", "CanPI %s, msg not sync, timeout" % cmd_name)
                 not_timeout = False
 
         return "KO"

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -36,7 +36,7 @@ class CanPI(object):
         config = configparser.ConfigParser()
         ini_file = "%s/%s.conf" % (self.hpsu.pathCOMMANDS, "pyhpsu")
         config.read(ini_file)
-        self.timeout = float(self.get_with_default(config=config, section="CANPI", name="timeout", default=0.05))
+        self.timeout = float(self.get_with_default(config=config, section="CANPI", name="timeout", default=0.1))
         self.retry = float(self.get_with_default(config=config, section="CANPI", name="retry", default=15))
         log_level = self.get_with_default(config=config, section="CANPI", name="log_level", default="ERROR")
         self.log_level_value = self._LEVELS.get(log_level.lower(), self._LEVELS["error"])

--- a/pyhpsu2mqtt/canpi.py
+++ b/pyhpsu2mqtt/canpi.py
@@ -11,7 +11,6 @@ try:
 except Exception:
     pass
 
-
 LOCK_FILE = "/run/pyhpsu-can.lock"
 
 
@@ -35,6 +34,14 @@ class CanPI(object):
         config.read(ini_file)
         self.timeout = float(self.get_with_default(config=config, section="CANPI", name="timeout", default=0.05))
         self.retry = float(self.get_with_default(config=config, section="CANPI", name="retry", default=15))
+
+    def __del__(self):
+        bus = getattr(self, "bus", None)
+        if bus is not None:
+            try:
+                bus.shutdown()
+            except Exception:
+                pass
 
     def get_with_default(self, config, section, name, default):
         if "config" not in config.sections():
@@ -116,9 +123,9 @@ class CanPI(object):
 
             if rc_bus:
                 if (
-                    msg_data[2] == 0xFA
-                    and msg_data[3] == rc_bus.data[3]
-                    and msg_data[4] == rc_bus.data[4]
+                        msg_data[2] == 0xFA
+                        and msg_data[3] == rc_bus.data[3]
+                        and msg_data[4] == rc_bus.data[4]
                 ) or (msg_data[2] != 0xFA and msg_data[2] == rc_bus.data[2]):
                     return "%02X %02X %02X %02X %02X %02X %02X" % (
                         rc_bus.data[0],

--- a/pyhpsu2mqtt/config.json
+++ b/pyhpsu2mqtt/config.json
@@ -4,7 +4,12 @@
   "slug": "pyhpsu2mqtt",
   "description": "pyHPSU - Connect via CAN bus to ROTEX/Daikin Heat Pump",
   "url": "https://github.com/m-reuter/ha-addons/tree/master/pyhpsu2mqtt",
-  "arch": ["armhf", "armv7", "aarch64", "amd64"],
+  "arch": [
+    "armhf",
+    "armv7",
+    "aarch64",
+    "amd64"
+  ],
   "startup": "system",
   "boot": "auto",
   "host_network": true,
@@ -20,8 +25,12 @@
     "mqtt_prefix": "rotex",
     "mqtt_commandtopic": "command",
     "canpi_timeout": 0.05,
-    "jobs" : [
-      { "command": "t_dhw", "interval": 10 }
+    "canpi_log_level": "ERROR",
+    "jobs": [
+      {
+        "command": "t_dhw",
+        "interval": 10
+      }
     ]
   },
   "schema": {
@@ -35,8 +44,12 @@
     "mqtt_prefix": "str",
     "mqtt_commandtopic": "str",
     "canpi_timeout": "float",
-    "jobs" : [
-      { "command": "str?", "interval": "int?" }
+    "canpi_log_level": "list(DEBUG|INFO|WARNING|ERROR)",
+    "jobs": [
+      {
+        "command": "str?",
+        "interval": "int?"
+      }
     ]
   },
   "image": "mreuter/{arch}-pyhpsu2mqtt"

--- a/pyhpsu2mqtt/config.json
+++ b/pyhpsu2mqtt/config.json
@@ -24,7 +24,7 @@
     "mqtt_clientname": "rotex_hpsu",
     "mqtt_prefix": "rotex",
     "mqtt_commandtopic": "command",
-    "canpi_timeout": 0.05,
+    "canpi_timeout": 0.1,
     "canpi_log_level": "ERROR",
     "jobs": [
       {

--- a/pyhpsu2mqtt/config.json
+++ b/pyhpsu2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "pyHPSU to MQTT Gateway",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "slug": "pyhpsu2mqtt",
   "description": "pyHPSU - Connect via CAN bus to ROTEX/Daikin Heat Pump",
   "url": "https://github.com/m-reuter/ha-addons/tree/master/pyhpsu2mqtt",

--- a/pyhpsu2mqtt/config.json
+++ b/pyhpsu2mqtt/config.json
@@ -44,7 +44,7 @@
     "mqtt_prefix": "str",
     "mqtt_commandtopic": "str",
     "canpi_timeout": "float",
-    "canpi_log_level": "list(DEBUG|INFO|WARNING|ERROR)",
+    "canpi_log_level": "list(WARNING|ERROR)",
     "jobs": [
       {
         "command": "str?",

--- a/pyhpsu2mqtt/mqtt_command_daemon.py
+++ b/pyhpsu2mqtt/mqtt_command_daemon.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import configparser
+import logging
+import os
+import subprocess
+import sys
+
+import paho.mqtt.client as mqtt
+
+
+LOGGER = logging.getLogger("pyhpsu-mqtt-command-daemon")
+
+
+def load_config(path):
+    config = configparser.ConfigParser()
+    if not config.read(path):
+        raise FileNotFoundError(f"config file not found: {path}")
+    return config
+
+
+def mqtt_settings(config):
+    section = config["MQTT"]
+    prefix = section.get("PREFIX", "").strip("/")
+    command_topic = section.get("COMMANDTOPIC", section.get("COMMAND", "command")).strip("/")
+    return {
+        "broker": section.get("BROKER", "localhost"),
+        "port": section.getint("PORT", 1883),
+        "username": section.get("USERNAME", fallback=None) or None,
+        "password": section.get("PASSWORD", fallback=None) or None,
+        "clientname": section.get("CLIENTNAME", "rotex_hpsu"),
+        "prefix": prefix,
+        "command_topic": command_topic,
+        "qos": section.getint("QOS", 0),
+    }
+
+
+def run_pyhpsu(conf_path, command, publish_result):
+    cmd = ["pyHPSU.py", "-f", conf_path, "-c", command]
+    if publish_result:
+        cmd.extend(["-o", "MQTT"])
+
+    LOGGER.info("Running %s", " ".join(cmd))
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        LOGGER.error("pyHPSU command failed (%s): %s", result.returncode, command)
+        if result.stdout:
+            LOGGER.error("stdout: %s", result.stdout.strip())
+        if result.stderr:
+            LOGGER.error("stderr: %s", result.stderr.strip())
+    elif result.stdout.strip():
+        LOGGER.debug("stdout: %s", result.stdout.strip())
+    elif result.stderr.strip():
+        LOGGER.debug("stderr: %s", result.stderr.strip())
+
+    return result.returncode == 0
+
+
+def on_connect(client, _userdata, _flags, reason_code, _properties=None):
+    if reason_code != 0:
+        LOGGER.error("MQTT connect failed with code %s", reason_code)
+        return
+
+    subscribe_topic = client.user_data_get()["subscribe_topic"]
+    qos = client.user_data_get()["qos"]
+    LOGGER.info("Subscribing to %s", subscribe_topic)
+    client.subscribe(subscribe_topic, qos=qos)
+
+
+def on_message(_client, userdata, message):
+    command = message.topic.rsplit("/", 1)[-1]
+    payload = message.payload.decode("utf-8").strip()
+    LOGGER.info("Received MQTT command %s=%s", command, payload or "<read>")
+
+    if payload.lower() in ("", "read"):
+        run_pyhpsu(userdata["conf_path"], command, publish_result=True)
+        return
+
+    if run_pyhpsu(userdata["conf_path"], f"{command}:{payload}", publish_result=False):
+        run_pyhpsu(userdata["conf_path"], command, publish_result=True)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    conf_path = sys.argv[1] if len(sys.argv) > 1 else "/etc/pyHPSU/pyhpsu.conf"
+    config = load_config(conf_path)
+    settings = mqtt_settings(config)
+
+    subscribe_topic = "/".join(part for part in (settings["prefix"], settings["command_topic"], "+") if part)
+    client_id = f"{settings['clientname']}-mqttdaemon-{os.getpid()}"
+
+    client = mqtt.Client(client_id=client_id)
+    if settings["username"]:
+        client.username_pw_set(settings["username"], settings["password"])
+    client.user_data_set(
+        {
+            "conf_path": conf_path,
+            "subscribe_topic": subscribe_topic,
+            "qos": settings["qos"],
+        }
+    )
+    client.on_connect = on_connect
+    client.on_message = on_message
+
+    LOGGER.info("Connecting to MQTT broker %s:%s", settings["broker"], settings["port"])
+    client.connect(settings["broker"], settings["port"])
+    client.loop_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyhpsu2mqtt/mqtt_command_daemon.py
+++ b/pyhpsu2mqtt/mqtt_command_daemon.py
@@ -3,11 +3,9 @@
 import configparser
 import logging
 import os
+import paho.mqtt.client as mqtt
 import subprocess
 import sys
-
-import paho.mqtt.client as mqtt
-
 
 LOGGER = logging.getLogger("pyhpsu-mqtt-command-daemon")
 
@@ -84,7 +82,7 @@ def on_connect(client, _userdata, _flags, reason_code, _properties=None):
 
 def on_message(_client, userdata, message):
     command = message.topic.rsplit("/", 1)[-1]
-    payload = message.payload.decode("utf-8").strip()
+    payload = message.payload.decode("utf-8", errors="replace").strip()
     LOGGER.info("Received MQTT command %s=%s", command, payload or "<read>")
 
     if payload.lower() in ("", "read"):

--- a/pyhpsu2mqtt/mqtt_command_daemon.py
+++ b/pyhpsu2mqtt/mqtt_command_daemon.py
@@ -12,6 +12,16 @@ import paho.mqtt.client as mqtt
 LOGGER = logging.getLogger("pyhpsu-mqtt-command-daemon")
 
 
+def make_client(client_id):
+    try:
+        return mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+            client_id=client_id,
+        )
+    except (AttributeError, TypeError, ValueError):
+        return mqtt.Client(client_id=client_id)
+
+
 def load_config(path):
     config = configparser.ConfigParser()
     if not config.read(path):
@@ -95,7 +105,7 @@ def main():
     subscribe_topic = "/".join(part for part in (settings["prefix"], settings["command_topic"], "+") if part)
     client_id = f"{settings['clientname']}-mqttdaemon-{os.getpid()}"
 
-    client = mqtt.Client(client_id=client_id)
+    client = make_client(client_id)
     if settings["username"]:
         client.username_pw_set(settings["username"], settings["password"])
     client.user_data_set(

--- a/pyhpsu2mqtt/mqtt_plugin.py
+++ b/pyhpsu2mqtt/mqtt_plugin.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import configparser
+import os
+import sys
+
+import paho.mqtt.client as mqtt
+
+
+def make_client(client_id):
+    try:
+        return mqtt.Client(
+            callback_api_version=mqtt.CallbackAPIVersion.VERSION2,
+            client_id=client_id,
+        )
+    except (AttributeError, TypeError, ValueError):
+        return mqtt.Client(client_id=client_id)
+
+
+class export:
+    hpsu = None
+
+    def __init__(self, hpsu=None, logger=None, config_file=None):
+        self.hpsu = hpsu
+        self.logger = logger
+        self.config_file = config_file
+        self.config = configparser.ConfigParser()
+        if os.path.isfile(self.config_file):
+            self.config.read(self.config_file)
+        else:
+            sys.exit(9)
+
+        mqtt_config = self.config["MQTT"]
+        self.brokerhost = mqtt_config.get("BROKER", "localhost")
+        self.brokerport = mqtt_config.getint("PORT", 1883)
+        self.clientname = mqtt_config.get("CLIENTNAME", "rotex")
+        self.username = mqtt_config.get("USERNAME", None)
+        self.password = mqtt_config.get("PASSWORD", "NoPasswordSpecified")
+        self.prefix = mqtt_config.get("PREFIX", "")
+        self.qos = mqtt_config.getint("QOS", 0)
+        self.retain = mqtt_config.get("RETAIN", "NOT TRUE") == "True"
+
+        client_name = f"{self.clientname}-{os.getpid()}"
+        self.client = make_client(client_name)
+        if self.username:
+            self.client.username_pw_set(self.username, password=self.password)
+        self.client.enable_logger()
+
+    def pushValues(self, vars=None):
+        self.client.connect(self.brokerhost, port=self.brokerport)
+        try:
+            for item in vars or []:
+                if self.prefix:
+                    topic = f"{self.prefix}/{item['name']}"
+                else:
+                    topic = item["name"]
+                self.client.publish(
+                    topic,
+                    payload=item["resp"],
+                    qos=int(self.qos),
+                    retain=self.retain,
+                )
+        finally:
+            self.client.disconnect()

--- a/pyhpsu2mqtt/mqtt_plugin.py
+++ b/pyhpsu2mqtt/mqtt_plugin.py
@@ -3,9 +3,8 @@
 
 import configparser
 import os
-import sys
-
 import paho.mqtt.client as mqtt
+import sys
 
 
 def make_client(client_id):
@@ -46,20 +45,28 @@ class export:
         if self.username:
             self.client.username_pw_set(self.username, password=self.password)
         self.client.enable_logger()
+        self.client.reconnect_delay_set(min_delay=1, max_delay=30)
+        self.client.connect_async(self.brokerhost, port=self.brokerport)
+        self.client.loop_start()
 
     def pushValues(self, vars=None):
-        self.client.connect(self.brokerhost, port=self.brokerport)
-        try:
-            for item in vars or []:
-                if self.prefix:
-                    topic = f"{self.prefix}/{item['name']}"
-                else:
-                    topic = item["name"]
-                self.client.publish(
-                    topic,
-                    payload=item["resp"],
-                    qos=int(self.qos),
-                    retain=self.retain,
-                )
-        finally:
-            self.client.disconnect()
+        for item in vars or []:
+            if self.prefix:
+                topic = f"{self.prefix}/{item['name']}"
+            else:
+                topic = item["name"]
+            self.client.publish(
+                topic,
+                payload=item["resp"],
+                qos=int(self.qos),
+                retain=self.retain,
+            )
+
+    def __del__(self):
+        client = getattr(self, "client", None)
+        if client is not None:
+            try:
+                client.loop_stop()
+                client.disconnect()
+            except Exception:
+                pass

--- a/pyhpsu2mqtt/mqtt_plugin.py
+++ b/pyhpsu2mqtt/mqtt_plugin.py
@@ -61,7 +61,7 @@ class export:
         self.password = mqtt_config.get("PASSWORD", "NoPasswordSpecified")
         self.prefix = mqtt_config.get("PREFIX", "")
         self.qos = mqtt_config.getint("QOS", 0)
-        self.retain = mqtt_config.get("RETAIN", "NOT TRUE") == "True"
+        self.retain = mqtt_config.getboolean("RETAIN", fallback=False)
 
         self.client = _shared_client(
             self.clientname, self.brokerhost, self.brokerport, self.username, self.password

--- a/pyhpsu2mqtt/mqtt_plugin.py
+++ b/pyhpsu2mqtt/mqtt_plugin.py
@@ -45,28 +45,20 @@ class export:
         if self.username:
             self.client.username_pw_set(self.username, password=self.password)
         self.client.enable_logger()
-        self.client.reconnect_delay_set(min_delay=1, max_delay=30)
-        self.client.connect_async(self.brokerhost, port=self.brokerport)
-        self.client.loop_start()
 
     def pushValues(self, vars=None):
-        for item in vars or []:
-            if self.prefix:
-                topic = f"{self.prefix}/{item['name']}"
-            else:
-                topic = item["name"]
-            self.client.publish(
-                topic,
-                payload=item["resp"],
-                qos=int(self.qos),
-                retain=self.retain,
-            )
-
-    def __del__(self):
-        client = getattr(self, "client", None)
-        if client is not None:
-            try:
-                client.loop_stop()
-                client.disconnect()
-            except Exception:
-                pass
+        self.client.connect(self.brokerhost, port=self.brokerport)
+        try:
+            for item in vars or []:
+                if self.prefix:
+                    topic = f"{self.prefix}/{item['name']}"
+                else:
+                    topic = item["name"]
+                self.client.publish(
+                    topic,
+                    payload=item["resp"],
+                    qos=int(self.qos),
+                    retain=self.retain,
+                )
+        finally:
+            self.client.disconnect()

--- a/pyhpsu2mqtt/mqtt_plugin.py
+++ b/pyhpsu2mqtt/mqtt_plugin.py
@@ -5,6 +5,7 @@ import configparser
 import os
 import paho.mqtt.client as mqtt
 import sys
+import threading
 
 
 def make_client(client_id):
@@ -15,6 +16,28 @@ def make_client(client_id):
         )
     except (AttributeError, TypeError, ValueError):
         return mqtt.Client(client_id=client_id)
+
+
+_client_lock = threading.Lock()
+_client = None
+
+
+def _shared_client(clientname, brokerhost, brokerport, username, password):
+    # export() is instantiated fresh per job cycle by pyHPSU's scheduler, so a
+    # per-instance connection would reconnect every time; reuse one
+    # process-wide connection across all instances instead.
+    global _client
+    with _client_lock:
+        if _client is None:
+            client = make_client(f"{clientname}-{os.getpid()}")
+            if username:
+                client.username_pw_set(username, password=password)
+            client.enable_logger()
+            client.reconnect_delay_set(min_delay=1, max_delay=30)
+            client.connect_async(brokerhost, port=brokerport)
+            client.loop_start()
+            _client = client
+        return _client
 
 
 class export:
@@ -40,25 +63,19 @@ class export:
         self.qos = mqtt_config.getint("QOS", 0)
         self.retain = mqtt_config.get("RETAIN", "NOT TRUE") == "True"
 
-        client_name = f"{self.clientname}-{os.getpid()}"
-        self.client = make_client(client_name)
-        if self.username:
-            self.client.username_pw_set(self.username, password=self.password)
-        self.client.enable_logger()
+        self.client = _shared_client(
+            self.clientname, self.brokerhost, self.brokerport, self.username, self.password
+        )
 
     def pushValues(self, vars=None):
-        self.client.connect(self.brokerhost, port=self.brokerport)
-        try:
-            for item in vars or []:
-                if self.prefix:
-                    topic = f"{self.prefix}/{item['name']}"
-                else:
-                    topic = item["name"]
-                self.client.publish(
-                    topic,
-                    payload=item["resp"],
-                    qos=int(self.qos),
-                    retain=self.retain,
-                )
-        finally:
-            self.client.disconnect()
+        for item in vars or []:
+            if self.prefix:
+                topic = f"{self.prefix}/{item['name']}"
+            else:
+                topic = item["name"]
+            self.client.publish(
+                topic,
+                payload=item["resp"],
+                qos=int(self.qos),
+                retain=self.retain,
+            )

--- a/pyhpsu2mqtt/pyHPSU.py
+++ b/pyhpsu2mqtt/pyHPSU.py
@@ -317,8 +317,10 @@ def read_can(n_hpsu, driver, logger, port, cmd, lg_code, verbose, output_type):
             else:
                 i += 1
                 time.sleep(2.0)
-                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
-                print("%s - WARNING - retry %s command %s" % (timestamp, i, c["name"]))
+                log_level = config.get('CANPI', 'log_level', fallback='ERROR').strip().upper()
+                if log_level != 'ERROR':
+                    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+                    print("%s - WARNING - retry %s command %s" % (timestamp, i, c["name"]))
                 if i == 4:
                     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
                     print("%s - ERROR - command %s failed" % (timestamp, c["name"]))

--- a/pyhpsu2mqtt/pyHPSU.py
+++ b/pyhpsu2mqtt/pyHPSU.py
@@ -309,7 +309,7 @@ def read_can(n_hpsu, driver, logger, port, cmd, lg_code, verbose, output_type):
             rc = n_hpsu.sendCommand(c, setValue)
             if rc != "KO":
                 i = 4
-                if not setValue:
+                if setValue is None:
                     response = n_hpsu.parseCommand(cmd=c, response=rc, verbose=verbose)
                     resp = n_hpsu.umConversion(cmd=c, response=response, verbose=verbose)
 

--- a/pyhpsu2mqtt/pyHPSU.py
+++ b/pyhpsu2mqtt/pyHPSU.py
@@ -18,6 +18,7 @@ import sys
 import threading
 import time
 from HPSU.HPSU import HPSU
+from datetime import datetime
 
 SocketPort = 7060
 
@@ -316,9 +317,11 @@ def read_can(n_hpsu, driver, logger, port, cmd, lg_code, verbose, output_type):
             else:
                 i += 1
                 time.sleep(2.0)
-                n_hpsu.printd('warning', 'retry %s command %s' % (i, c["name"]))
+                timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+                print("%s - WARNING - retry %s command %s" % (timestamp, i, c["name"]))
                 if i == 4:
-                    n_hpsu.printd('error', 'command %s failed' % (c["name"]))
+                    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")[:-3]
+                    print("%s - ERROR - command %s failed" % (timestamp, c["name"]))
 
     if output_type == "JSON":
         if len(arrResponse) != 0:

--- a/pyhpsu2mqtt/pyHPSU.py
+++ b/pyhpsu2mqtt/pyHPSU.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+#
+# -*- coding: utf-8 -*-
+
+
+import configparser
+import csv
+import getopt
+import importlib
+import json
+import locale
+import logging
+# sys.path.append('/usr/share/pyHPSU/HPSU')
+# sys.path.append('/usr/share/pyHPSU/plugins')
+import os
+import serial
+import sys
+import threading
+import time
+from HPSU.HPSU import HPSU
+
+SocketPort = 7060
+
+
+def main(argv):
+    cmd = []
+    port = None
+    driver = "PYCAN"
+    verbose = "1"
+    show_help = False
+    output_type = ""
+    upload = False
+    lg_code = "EN"
+    languages = ["EN", "IT", "DE"]
+    logger = None
+    pathCOMMANDS = "/etc/pyHPSU"
+    global conf_file
+    conf_file = None
+    global default_conf_file
+    default_conf_file = "/etc/pyHPSU/pyhpsu.conf"
+    read_from_conf_file = False
+    global auto
+    global ticker
+    ticker = 0
+    loop = True
+    auto = False
+    # commands = []
+    # listCommands = []
+    global config
+    config = configparser.ConfigParser()
+    global n_hpsu
+    env_encoding = sys.stdout.encoding
+    PLUGIN_PATH = "/usr/lib/python3/dist-packages/HPSU/plugins"
+    backup_mode = False
+    global backup_file
+    restore_mode = False
+    global options_list
+    options_list = {}
+    #
+    # get all plugins
+    #
+    PLUGIN_LIST = ["JSON", "CSV", "BACKUP"]
+    PLUGIN_STRING = "JSON, CSV, BACKUP"
+    for file in os.listdir(PLUGIN_PATH):
+        if file.endswith(".py") and not file.startswith("__"):
+            PLUGIN = file.upper().split(".")[0]
+            PLUGIN_STRING += ", "
+            PLUGIN_STRING += PLUGIN
+            PLUGIN_LIST.append(PLUGIN)
+
+    try:
+        opts, args = getopt.getopt(argv, "ahc:p:d:v:o:l:g:f:b:r:",
+                                   ["help", "cmd=", "port=", "driver=", "verbose=", "output_type=", "upload=",
+                                    "language=", "log=", "config_file="])
+    except getopt.GetoptError:
+        print('pyHPSU.py -d DRIVER -c COMMAND')
+        print(' ')
+        print('           -a  --auto            do atomatic queries')
+        print('           -f  --config          Configfile, overrides given commandline arguments')
+        print('           -d  --driver          driver name: [ELM327, PYCAN, EMU, HPSUD], Default: PYCAN')
+        print('           -p  --port            port (eg COM or /dev/tty*, only for ELM327 driver)')
+        print('           -o  --output_type     output type: [' + PLUGIN_STRING + '] default JSON')
+        print('           -c  --cmd             command: [see commands domain]')
+        print('           -v  --verbose         verbosity: [1, 2]   default 1')
+        print('           -l  --language        set the language to use [%s], default is \"EN\" ' % " ".join(languages))
+        print('           -b  --backup          backup configurable settings to file [filename]')
+        print('           -r  --restore         restore HPSU settings from file [filename]')
+        print('           -g  --log             set the log to file [_filename]')
+        print('           -h  --help            show help')
+        sys.exit(2)
+
+    for opt, arg in opts:
+        if opt in ("-a", "--auto"):
+            auto = True
+            options_list["auto"] = ""
+
+        if opt in ("-f", "--config"):
+            read_from_conf_file = True
+            conf_file = arg
+            options_list["config"] = arg
+
+        if opt in ("-b", "--backup"):
+            backup_mode = True
+            backup_file = arg
+            output_type = "BACKUP"
+            options_list["backup"] = arg
+
+        if opt in ("-r", "--restore"):
+            restore_mode = True
+            backup_file = arg
+            options_list["restore"] = arg
+
+        if opt in ("-h", "--help"):
+            show_help = True
+            options_list["help"] = ""
+
+        elif opt in ("-d", "--driver"):
+            driver = arg.upper()
+            options_list["driver"] = arg.upper()
+
+        elif opt in ("-p", "--port"):
+            port = arg
+            options_list["port"] = arg
+
+        elif opt in ("-c", "--cmd"):
+            cmd.append(arg)
+
+        elif opt in ("-v", "--verbose"):
+            verbose = arg
+            options_list["verbose"] = ""
+
+        elif opt in ("-o", "--output_type"):
+            output_type = arg.upper()
+            options_list["output_type"] = arg.upper()
+
+        elif opt in ("-l", "--language"):
+            lg_code = arg.upper()
+            options_list["language"] = arg.upper()
+
+        elif opt in ("-g", "--log"):
+            logger = logging.getLogger('pyhpsu')
+            hdlr = logging.FileHandler(arg)
+            formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+            hdlr.setFormatter(formatter)
+            logger.addHandler(hdlr)
+            logger.setLevel(logging.ERROR)
+        options_list["cmd"] = cmd
+    if verbose == "2":
+        locale.setlocale(locale.LC_ALL, '')
+
+    # config if in auto mode
+    if auto:
+        read_from_conf_file = True
+        conf_file = default_conf_file
+
+    # get config from file if given....
+    if read_from_conf_file:
+        if conf_file == None:
+            print("Error, please provide a config file")
+            sys.exit(9)
+        else:
+            try:
+                with open(conf_file) as f:
+                    config.read_file(f)
+            except IOError:
+                print("Error: config file not found")
+                sys.exit(9)
+        config.read(conf_file)
+        if driver == "" and config.has_option('PYHPSU', 'PYHPSU_DEVICE'):
+            driver = config['PYHPSU']['PYHPSU_DEVICE']
+        if port == "" and config.has_option('PYHPSU', 'PYHPSU_PORT'):
+            port = config['PYHPSU']['PYHPSU_PORT']
+        if lg_code == "" and config.has_option('PYHPSU', 'PYHPSU_LANG'):
+            lg_code = config['PYHPSU']['PYHPSU_LANG']
+        if output_type == "" and config.has_option('PYHPSU', 'OUTPUT_TYPE'):
+            output_type = config['PYHPSU']['OUTPUT_TYPE']
+
+    else:
+        conf_file = default_conf_file
+    if output_type == "":
+        output_type = "JSON"
+    #
+    # now we should have all options...let's check them
+    #
+    # Check driver
+    if driver not in ["ELM327", "PYCAN", "EMU", "HPSUD"]:
+        print("Error, please specify a correct driver [ELM327, PYCAN, EMU, HPSUD] ")
+        sys.exit(9)
+
+    if driver == "ELM327" and port == "":
+        print("Error, please specify a correct port for the ELM327 device ")
+        sys.exit(9)
+
+    # Check output type
+    if output_type not in PLUGIN_LIST:
+        print("Error, please specify a correct output_type [" + PLUGIN_STRING + "]")
+        sys.exit(9)
+
+    # Check Language
+    if lg_code not in languages:
+        print("Error, please specify a correct language [%s]" % " ".join(languages))
+        sys.exit(9)
+    # ------------------------------------
+    # try to query different commands in different periods
+    # Read them from config and group them
+    #
+    # create dictionary for the jobs
+    if auto:
+        timed_jobs = dict()
+        if read_from_conf_file:  # if config is read from file
+            if len(config.options('JOBS')):  # if there are configured jobs
+                for each_key in config.options('JOBS'):  # for each value to query
+                    job_period = config.get('JOBS', each_key)  # get the period
+                    if not "timer_" + job_period in timed_jobs.keys():  # if this period isn't still in the dict
+                        timed_jobs["timer_" + job_period] = []  # create a list for this period
+                    timed_jobs["timer_" + job_period].append(each_key)  # and add the value to this period
+                wanted_periods = list(timed_jobs.keys())
+            else:
+                print("Error, please specify a value to query in config file ")
+                sys.exit(9)
+
+    #
+    # Print help
+    #
+    if show_help:
+        n_hpsu = HPSU(driver=None, logger=logger, port=port, cmd=cmd, lg_code=lg_code)
+        if len(cmd) == 0:
+            print("List available commands:")
+            print("%20s - %-10s" % ('COMMAND', 'LABEL'))
+            print("%20s---%-10s" % ('------------', '----------'))
+            for cmd in sorted(n_hpsu.command_dict):
+                try:
+                    print("%20s - %-10s" % (n_hpsu.command_dict[cmd]['name'], n_hpsu.command_dict[cmd]['label']))
+                except KeyError:
+                    print("""!!!!!! No translation for "%12s" !!!!!!!""" % (n_hpsu.command_dict[cmd]['name']))
+        else:
+            print("%12s - %-10s - %s" % ('COMMAND', 'LABEL', 'DESCRIPTION'))
+            print("%12s---%-10s---%s" % ('------------', '----------',
+                                         '---------------------------------------------------'))
+            for c in n_hpsu.commands:
+                print("%12s - %-10s - %s" % (c['name'], c['label'], c['desc']))
+        sys.exit(0)
+
+        #
+        # now its time to call the hpsu and do the REAL can query
+        # and handle the data as configured
+        #
+    if auto and not backup_mode:
+        while loop:
+            ticker += 1
+            collected_cmds = []
+            for period_string in timed_jobs.keys():
+                period = period_string.split("_")[1]
+                if not ticker % int(period):
+                    for job in timed_jobs[period_string]:
+                        collected_cmds.append(str(job))
+            if len(collected_cmds):
+                n_hpsu = HPSU(driver=driver, logger=logger, port=port, cmd=collected_cmds, lg_code=lg_code)
+                exec(
+                    'thread_%s = threading.Thread(target=read_can, args=(n_hpsu,driver,logger,port,collected_cmds,lg_code,verbose,output_type))' % (
+                        period))
+                exec('thread_%s.start()' % (period))
+            time.sleep(1)
+    elif backup_mode:
+        n_hpsu = HPSU(driver=driver, logger=logger, port=port, cmd=cmd, lg_code=lg_code)
+        read_can(n_hpsu, driver, logger, port, n_hpsu.backup_commands, lg_code, verbose, output_type)
+    elif restore_mode:
+        restore_commands = []
+        try:
+            with open(backup_file, 'r') as jsonfile:
+                restore_settings = json.load(jsonfile)
+                for command in restore_settings:
+                    restore_commands.append(str(command["name"]) + ":" + str(command["resp"]))
+                n_hpsu = HPSU(driver=driver, logger=logger, port=port, cmd=restore_commands, lg_code=lg_code)
+                read_can(n_hpsu, driver, logger, port, restore_commands, lg_code, verbose, output_type)
+        except FileNotFoundError:
+            print("No such file or directory!!!")
+            sys.exit(1)
+
+    else:
+        n_hpsu = HPSU(driver=driver, logger=logger, port=port, cmd=cmd, lg_code=lg_code)
+        read_can(n_hpsu, driver, logger, port, cmd, lg_code, verbose, output_type)
+
+
+def read_can(n_hpsu, driver, logger, port, cmd, lg_code, verbose, output_type):
+    global backup_file
+    # really needed? Driver is checked above
+    # if not driver:
+    #    print("Error, please specify driver [ELM327 or PYCAN, EMU, HPSUD]")
+    #    sys.exit(9)
+
+    arrResponse = []
+
+    for c in n_hpsu.commands:
+        setValue = None
+        for i in cmd:
+            if ":" in i and c["name"] == i.split(":")[0]:
+                setValue = i.split(":")[1]
+                if not c["type"] == "value":
+                    setValue = float(setValue) * float(c["divisor"])
+                else:
+                    if not setValue.isdigit():
+                        key = str(setValue)
+                        setValue = c["value_code"][str(setValue)]
+
+        i = 0
+        while i <= 3:
+            rc = n_hpsu.sendCommand(c, setValue)
+            if rc != "KO":
+                i = 4
+                if not setValue:
+                    response = n_hpsu.parseCommand(cmd=c, response=rc, verbose=verbose)
+                    resp = n_hpsu.umConversion(cmd=c, response=response, verbose=verbose)
+
+                    arrResponse.append({"name": c["name"], "resp": resp, "timestamp": response["timestamp"]})
+            else:
+                i += 1
+                time.sleep(2.0)
+                n_hpsu.printd('warning', 'retry %s command %s' % (i, c["name"]))
+                if i == 4:
+                    n_hpsu.printd('error', 'command %s failed' % (c["name"]))
+
+    if output_type == "JSON":
+        if len(arrResponse) != 0:
+            arrResponse = json.dumps(arrResponse)
+            print(arrResponse)
+    elif output_type == "CSV":
+        for r in arrResponse:
+            print("%s,%s,%s" % (r["timestamp"], r["name"], r["resp"]))
+    elif output_type == "BACKUP":
+        print("Writing Backup to " + str(backup_file))
+        try:
+            with open(backup_file, 'w') as outfile:
+                json.dump(arrResponse, outfile, sort_keys=True, indent=4, ensure_ascii=False)
+        except FileNotFoundError:
+            print("No such file or directory!!!")
+            sys.exit(1)
+    else:
+        module_name = output_type.lower()
+        module = importlib.import_module("HPSU.plugins." + module_name)
+        hpsu_plugin = module.export(hpsu=n_hpsu, logger=logger, config_file=conf_file)
+        hpsu_plugin.pushValues(vars=arrResponse)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/pyhpsu2mqtt/pyHPSU.py
+++ b/pyhpsu2mqtt/pyHPSU.py
@@ -76,7 +76,7 @@ def main(argv):
     except getopt.GetoptError:
         print('pyHPSU.py -d DRIVER -c COMMAND')
         print(' ')
-        print('           -a  --auto            do atomatic queries')
+        print('           -a  --auto            do automatic queries')
         print('           -f  --config          Configfile, overrides given commandline arguments')
         print('           -d  --driver          driver name: [ELM327, PYCAN, EMU, HPSUD], Default: PYCAN')
         print('           -p  --port            port (eg COM or /dev/tty*, only for ELM327 driver)')

--- a/pyhpsu2mqtt/pyhpsu.conf
+++ b/pyhpsu2mqtt/pyhpsu.conf
@@ -1,9 +1,3 @@
-# settings for pyHPSUd 
-#[PYHPSUD]
-#PYHPSUD_DEVICE = {pyhpsud_device}
-#PYHPSUD_LANG = {pyhpsud_lang}
-#PYHPSUD_PORT = {pyhpsud_port}
-
 # settings for pyHPSU
 [PYHPSU]
 PYHPSU_DEVICE = {pyhpsu_device}

--- a/pyhpsu2mqtt/pyhpsu.conf
+++ b/pyhpsu2mqtt/pyhpsu.conf
@@ -22,6 +22,7 @@ COMMANDTOPIC = {mqtt_commandtopic}
 
 [CANPI]
 timeout={canpi_timeout}
+log_level = {canpi_log_level}
 
 # interval for each query for a value in seconds
 # values not listed here are not queried

--- a/pyhpsu2mqtt/run.sh
+++ b/pyhpsu2mqtt/run.sh
@@ -31,13 +31,13 @@ sed -i "s/{canpi_timeout}/${CANPI_TIMEOUT}/g" "pyhpsu.conf"
 sed -i "s/{canpi_log_level}/${CANPI_LOG_LEVEL}/g" "pyhpsu.conf"
 sed -i "s/{jobs}/${JOBS//$'\n'/\\n}/g" "pyhpsu.conf"
 
-echo "Initializing pyhpsu configuration ..."
+echo "$(date '+%Y-%m-%d %H:%M:%S') - Initializing pyhpsu configuration ..."
 cp pyhpsu.conf /etc/pyHPSU/pyhpsu.conf
 
 echo
-echo "pyHPSU configuration (sensitive values redacted):"
+echo "$(date '+%Y-%m-%d %H:%M:%S') - pyHPSU configuration (sensitive values redacted):"
 echo
-sed -E 's/^([[:space:]]*PASSWORD[[:space:]]*=[[:space:]]*).*/\1<redacted>/' pyhpsu.conf
+sed -E 's/^([[:space:]]*PASSWORD[[:space:]]*=[[:space:]]*).*/\1<redacted>/' pyhpsu.conf | sed 's/^/    /'
 echo
 
 export PYTHONPATH="/usr/lib/python3/dist-packages"

--- a/pyhpsu2mqtt/run.sh
+++ b/pyhpsu2mqtt/run.sh
@@ -38,5 +38,14 @@ echo
 sed -E 's/^([[:space:]]*PASSWORD[[:space:]]*=[[:space:]]*).*/\1<redacted>/' pyhpsu.conf
 echo
 
+python3 /usr/local/bin/mqtt_command_daemon.py /etc/pyHPSU/pyhpsu.conf &
+MQTT_DAEMON_PID=$!
+
+cleanup() {
+    kill "${MQTT_DAEMON_PID}" 2>/dev/null || true
+}
+
+trap cleanup EXIT INT TERM
+
 export PYTHONPATH="/usr/lib/python3/dist-packages"
-pyHPSU.py --mqtt_daemon -a -o mqtt
+pyHPSU.py -a -o MQTT

--- a/pyhpsu2mqtt/run.sh
+++ b/pyhpsu2mqtt/run.sh
@@ -12,6 +12,7 @@ MQTT_CLIENTNAME="$(bashio::config 'mqtt_clientname')"
 MQTT_PREFIX="$(bashio::config 'mqtt_prefix')"
 MQTT_COMMANDTOPIC="$(bashio::config 'mqtt_commandtopic')"
 CANPI_TIMEOUT="$(bashio::config 'canpi_timeout')"
+CANPI_LOG_LEVEL="$(bashio::config 'canpi_log_level')"
 JOBS=$(jq -r 'if .jobs then [.jobs[] | .command+"="+(.interval|tostring) ] | join("\n") else "" end' /data/options.json)
 
 
@@ -27,6 +28,7 @@ sed -i "s/{mqtt_clientname}/${MQTT_CLIENTNAME}/g" "pyhpsu.conf"
 sed -i "s#{mqtt_prefix}#${MQTT_PREFIX}#g" "pyhpsu.conf"
 sed -i "s#{mqtt_commandtopic}#${MQTT_COMMANDTOPIC}#g" "pyhpsu.conf"
 sed -i "s/{canpi_timeout}/${CANPI_TIMEOUT}/g" "pyhpsu.conf"
+sed -i "s/{canpi_log_level}/${CANPI_LOG_LEVEL}/g" "pyhpsu.conf"
 sed -i "s/{jobs}/${JOBS//$'\n'/\\n}/g" "pyhpsu.conf"
 
 echo "Initializing pyhpsu configuration ..."

--- a/pyhpsu2mqtt/run.sh
+++ b/pyhpsu2mqtt/run.sh
@@ -38,6 +38,8 @@ echo
 sed -E 's/^([[:space:]]*PASSWORD[[:space:]]*=[[:space:]]*).*/\1<redacted>/' pyhpsu.conf
 echo
 
+export PYTHONPATH="/usr/lib/python3/dist-packages"
+
 python3 /usr/local/bin/mqtt_command_daemon.py /etc/pyHPSU/pyhpsu.conf &
 MQTT_DAEMON_PID=$!
 
@@ -47,5 +49,4 @@ cleanup() {
 
 trap cleanup EXIT INT TERM
 
-export PYTHONPATH="/usr/lib/python3/dist-packages"
 pyHPSU.py -a -o MQTT


### PR DESCRIPTION
## Summary

This branch moves the add-on's pyHPSU base from the old release's `pull/54/head` (the last commit ever merged into pyHPSU's `testing` branch, frozen since 2022-02-25) to a current `master` commit. Since `master` never received `testing`'s MQTT daemon work, this branch reimplements the missing MQTT functionality, fixes several real upstream bugs found along the way, and adds diagnostics/tuning options — all validated with extensive live side-by-side testing against the previous release.

## Why not just keep using the old base?

`testing` — the only pyHPSU branch that ever had MQTT daemon support — has had no commits since February 2022. Building on `master` instead trades a modest amount of reimplementation work for staying on an actively maintained upstream base.

## What's included

**MQTT daemon functionality (reimplemented, since `master` never had it):**
- `mqtt_command_daemon.py`: standalone listener for incoming MQTT write/read commands (`<prefix>/command/...`), replacing the `--mqtt_daemon` flag that only ever existed on `testing`.
- `mqtt_plugin.py`: `paho-mqtt` 2.x-compatible output plugin with a persistent, process-wide MQTT connection (connect once, reused across all job publishes) instead of reconnecting on every single publish.

**Correctness fixes:**
- Fixed a race condition in pyHPSU's `-a` auto-mode scheduler: `read_can()` read a module-global `n_hpsu` that the scheduler reassigns on every job-period tick, so overlapping job threads could corrupt each other's `HPSU`/`CanPI`/bus instance mid-run. Now passed explicitly per-thread.
- Fixed `get_with_default()` in `canpi.py`, which checked for a literal (never-matching) `"config"` section name instead of checking the requested option — silently ignored every `pyhpsu.conf` override and always fell back to hardcoded defaults.
- Fixed `value`-type write commands: the high byte was hardcoded to `00` instead of being split from `setValue`, corrupting any write with a value > 255.
- Fixed `CanPI.__del__` to actually call `bus.shutdown()`.
- Fixed `run.sh` starting the MQTT command daemon before `PYTHONPATH` was exported, breaking its ability to import `HPSU`.
- Fixed a buffer issue in log output so that log message are visible when they are produced. 

**Diagnostics/tuning:**
- New `canpi_log_level` add-on option (`WARNING`/`ERROR`, default `ERROR`) to control CAN retry/timeout log verbosity independently of production noise.
- Command names and consistent `TIMESTAMP - LEVEL - message` formatting added to all CAN diagnostic log lines (previously anonymous `SEND`/`RECV`/retry lines with no command context or timestamp).
- `canpi_timeout` default raised from `0.05` to `0.1`, measured more reliable in extended live testing.

**Docs:**
- README notes on troubleshooting per-command failures (some pyHPSU commands don't respond on all heat pump firmware), corrected explanation of why `host_network` is required, general cleanup.

## Testing

Run side-by-side against the previous release (`mreuter/aarch64-pyhpsu2mqtt:0.9.4`) on real hardware for multiple hours at a time, with the full staggered job list (17 commands, intervals 52–69s). This branch's CAN timeout rate now matches or beats the old release's. Write commands (e.g. `t_dhw_setpoint1`) verified working end-to-end through the new MQTT command daemon.